### PR TITLE
Update for ngx-translate 6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,22 +29,22 @@
   },
   "config": {},
   "peerDependencies": {
-    "@angular/core": "^2.0.0",
-    "@angular/http": "^2.0.0",
-    "ng2-translate": "^5.0.0"
+    "@angular/core": ">=2.3.0 || >=4.0.0-beta.0",
+    "@angular/http": ">=2.3.0 || >=4.0.0-beta.0",
+    "@ngx-translate/core": "^6.0.0"
   },
   "dependencies": {
     "gettext-parser": "1.2.1"
   },
   "devDependencies": {
-    "@angular/core": "2.2.1",
-    "@angular/common": "2.2.1",
-    "@angular/platform-browser": "2.2.1",
-    "@angular/http": "2.2.1",
-    "rxjs": "5.0.0-beta.12",
-    "zone.js": "0.6.21",
+    "@angular/core": "2.4.6",
+    "@angular/common": "2.4.6",
+    "@angular/platform-browser": "2.4.6",
+    "@angular/http": "2.4.6",
+    "rxjs": "5.0.1",
+    "zone.js": "0.7.6",
     "typescript": "2.0.10",
-    "ng2-translate": "5.0.0",
+    "@ngx-translate/core": "^6.0.0",
     "tslint": "4.2.0",
     "tslint-eslint-rules": "3.2.1"
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { Http, Response } from '@angular/http';
 
 import { Observable } from 'rxjs/Observable';
-import { TranslateLoader } from 'ng2-translate';
+import {TranslateLoader} from '@ngx-translate/core';
 import * as gettext from 'gettext-parser';
 
 export class TranslatePoLoader implements TranslateLoader {


### PR DESCRIPTION
This PR makes the loader compatible with ngx-translate 6.0.0

Changes:
- Change name from ng2-translate to ngx-translate/core
- Updated dependency versions