### PR TITLE
Update ng2-translate to ngx-translate

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "@angular/core": "^2.0.0",
     "@angular/http": "^2.0.0",
-    "ng2-translate": "^5.0.0"
+    "@ngx-translate/core": "^6.0.0"
   },
   "dependencies": {
     "gettext-parser": "1.2.1"
@@ -44,7 +44,7 @@
     "rxjs": "5.0.0-beta.12",
     "zone.js": "0.6.21",
     "typescript": "2.0.10",
-    "ng2-translate": "5.0.0",
+    "@ngx-translate/core": "^6.0.0"
     "tslint": "4.2.0",
     "tslint-eslint-rules": "3.2.1"
   }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "rxjs": "5.0.0-beta.12",
     "zone.js": "0.6.21",
     "typescript": "2.0.10",
-    "@ngx-translate/core": "^6.0.0"
+    "@ngx-translate/core": "^6.0.0",
     "tslint": "4.2.0",
     "tslint-eslint-rules": "3.2.1"
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { Http, Response } from '@angular/http';
 
 import { Observable } from 'rxjs/Observable';
-import { TranslateLoader } from 'ng2-translate';
+import {TranslateLoader} from '@ngx-translate/core';
 import * as gettext from 'gettext-parser';
 
 export class TranslatePoLoader implements TranslateLoader {


### PR DESCRIPTION
Changing import and dependency to ngx-translate.
No change of angular version dependency (like in the fork of jsprds).

It's my first fork / pull request, so I hope it is correct :)