### PR TITLE
Updated angular peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
   },
   "config": {},
   "peerDependencies": {
-    "@angular/core": "^2.0.0",
-    "@angular/http": "^2.0.0",
+    "@angular/core": "^2.0.0 || ^4.0.0",
+    "@angular/http": "^2.0.0 || ^4.0.0",
     "@ngx-translate/core": "^6.0.0"
   },
   "dependencies": {


### PR DESCRIPTION
The peerDependency in `package.json` for `@angular/core` and `@angular/http` were set to ng 2.0

This causes a warning for people on ng 4. More seriously, it prevents `npm shrinkwrap` from working for ng4 users.

This PR updates the peer dependencies.

@biesbjerg