### PR TITLE
Add support for HttpClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,23 +3,23 @@ Load po files for use with `ngx-translate`
 
 ## Usage:
 ```ts
-import { Http } from '@angular/http';
+import { HttpClient, HttpClientModule } from '@angular/common/http';
 
 import { TranslatePoHttpLoader } from '@biesbjerg/ngx-translate-po-http-loader';
 
-export function createTranslateLoader(http: Http) {
+export function createTranslateLoader(http: HttpClient) {
 	return new TranslatePoHttpLoader(http, 'assets/i18n', '.po');
 }
 
 @NgModule({
 	imports: [
 		BrowserModule,
-		HttpModule,
+		HttpClientModule,
 		TranslateModule.forRoot({
 			loader: {
 				provide: TranslateLoader,
 				useFactory: createTranslateLoader,
-				deps: [Http]
+				deps: [HttpClient]
 			}
 		})
 	],

--- a/package.json
+++ b/package.json
@@ -29,22 +29,21 @@
   },
   "config": {},
   "peerDependencies": {
-    "@angular/core": "^2.0.0 || ^4.0.0",
-    "@angular/http": "^2.0.0 || ^4.0.0",
-    "@ngx-translate/core": "^6.0.0"
+    "@angular/core": "^4.3.0",
+    "@angular/common": "^4.3.0",
+    "@ngx-translate/core": "^7.0.0"
   },
   "dependencies": {
     "gettext-parser": "1.2.2"
   },
   "devDependencies": {
-    "@angular/core": "2.2.1",
-    "@angular/common": "2.2.1",
-    "@angular/platform-browser": "2.2.1",
-    "@angular/http": "2.2.1",
-    "rxjs": "5.0.0-beta.12",
-    "zone.js": "0.6.21",
-    "typescript": "2.0.10",
-    "@ngx-translate/core": "6.0.0",
+    "@angular/core": "4.3.1",
+    "@angular/common": "4.3.1",
+    "@angular/platform-browser": "4.3.1",
+    "rxjs": "5.4.3",
+    "zone.js": "0.8.11",
+    "typescript": "2.3.4",
+    "@ngx-translate/core": "7.0.0",
     "tslint": "4.5.1",
     "tslint-eslint-rules": "3.4.0"
   }

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
   },
   "config": {},
   "peerDependencies": {
-    "@angular/core": "^4.3.0",
-    "@angular/common": "^4.3.0",
+    "@angular/core": ">= 4.3.0 < 6.0.0",
+    "@angular/common": ">= 4.3.0 < 6.0.0",
     "@ngx-translate/core": "^8.0.0"
   },
   "dependencies": {
@@ -43,7 +43,7 @@
     "rxjs": "5.4.3",
     "zone.js": "0.8.11",
     "typescript": "2.3.4",
-    "@ngx-translate/core": "7.0.0",
+    "@ngx-translate/core": "8.0.0",
     "tslint": "4.5.1",
     "tslint-eslint-rules": "3.4.0"
   }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "@angular/core": "^4.3.0",
     "@angular/common": "^4.3.0",
-    "@ngx-translate/core": "^7.0.0"
+    "@ngx-translate/core": "^8.0.0"
   },
   "dependencies": {
     "gettext-parser": "1.2.2"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { Http, Response } from '@angular/http';
+import { HttpClient } from '@angular/common/http';
 
 import { Observable } from 'rxjs/Observable';
 import { TranslateLoader } from '@ngx-translate/core';
@@ -12,7 +12,7 @@ export class TranslatePoHttpLoader implements TranslateLoader {
 	public domain = '';
 
 	constructor(
-		protected _http: Http,
+		protected _http: HttpClient,
 		protected _prefix: string = 'i18n',
 		protected _suffix: string = '.po'
 	) {
@@ -25,8 +25,7 @@ export class TranslatePoHttpLoader implements TranslateLoader {
 	 */
 	public getTranslation(lang: string): Observable<any> {
 		return this._http
-			.get(`${this._prefix}/${lang}${this._suffix}`)
-			.map((response: Response) => response.text())
+			.get(`${this._prefix}/${lang}${this._suffix}`, { responseType: 'text' })
 			.map((contents: string) => this.parse(contents));
 	}
 


### PR DESCRIPTION
I tried to match the `package.json` for [ngx-translate/http-loader](https://github.com/ngx-translate/http-loader/blob/v1.0.2/package.json) which now supports HttpClient.

I updated the `index.ts` to use `HttpClient` instead of `Http`

I wasn't sure if you wanted the peerDependencies set as a range to accept @angular 5.x as well?

This should fix https://github.com/biesbjerg/ngx-translate-po-http-loader/issues/9